### PR TITLE
some fixes I made so that templates.js would not crash on the client side

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -42,7 +42,9 @@
 			worker = new Worker(pathToScript);
 
 			worker.addEventListener('message', function(e) {
-				callbacks[e.data.signature](e.data.result);
+				if (callbacks[e.data.signature]) {
+					callbacks[e.data.signature](e.data.result);
+				}
 			}, false);
 		} catch (err) {}
 	};
@@ -52,6 +54,8 @@
 		if (signature > MAX_SAFE_INT) {
 			signature = 0;
 		}
+
+		obj = sanitise(obj);
 
 		worker.postMessage({
 			template: template,
@@ -64,6 +68,16 @@
 			callback(result);
 			delete callbacks[signature];
 		};
+	}
+
+	function sanitise(obj) {
+		for(var prop in obj) {
+			if (!obj.hasOwnProperty(prop) || typeof obj[prop] === 'function') {
+				delete obj[prop];
+			}
+		}
+
+		return obj;
 	}
 
 	templates.parse = function(template, block, obj, callback) {


### PR DESCRIPTION
Got this error on Chrome, and only on the `disney` branch:

`Uncaught DataCloneError: An object could not be cloned.`

Related:
  * http://www.nowherenearithaca.com/2013/07/solved-chrome-web-workers-and.html
  * https://github.com/csantanapr/dapp-examples/issues/31

So I fixed it :shipit: 

As for wrapping `callbacks[e.data.signature]` in a conditional, I was getting `undefined is not a function` errors as well... there's probably an underlying issue for that, but this works as a bandaid.

----

![](http://i.imgur.com/xVyoSl.jpg)