### PR TITLE
Replace all variables for each iteration

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -351,12 +351,12 @@
 					.replace(regexes.removeTabspace, '');
 
 				if (!isObject) {
-					result = result.replace('@index', iterator);
-					result = result.replace('@value', array[iterator]);
+					result = result.replace(/@index/g, iterator);
+					result = result.replace(/@value/g, array[iterator]);
 				} else {
 					result = result
-						.replace('@key', iterator)
-						.replace('@value', array[iterator]);
+						.replace(/@key/g, iterator)
+						.replace(/@value/g, array[iterator]);
 				}
 
 				result = parseFunctions(block, result, array[iterator]);


### PR DESCRIPTION
To reproduce the bug:
```
//Object
myobject = {one:'1', two:'2', three:'3'};

//Template
<!-- BEGIN myobject -->
Values are: @key - @value<br />
Values should be even: @key - @value<br />
Values should always be: @key - @value<br />
<!-- END myobject -->
```

```
//Array
myarray = ['one', 'two', 'three'];

//Template
<!-- BEGIN myarray -->
Values are: @index - @value<br />
Values should be even: @index - @value<br />
Values should always be: @index - @value<br />
<!-- END myarray -->
```